### PR TITLE
set logo to two-thirds class so it will scale down on smaller screens

### DIFF
--- a/src/main/scala/nyc2014/templates.scala
+++ b/src/main/scala/nyc2014/templates.scala
@@ -362,7 +362,7 @@ trait Templates {
     <div class="grid">
       <div class="unit whole center title">
         <a href="/" class="logo">
-          <img src="/images/2014-logo.svg" alt="north east scala symposium logo"></img>
+          <img class="two-thirds" src="/images/2014-logo.svg" alt="north east scala symposium logo"></img>
         </a>
         <div class="center">
           <hr/>


### PR DESCRIPTION
I tested this in change with ff/chrome dev tools but haven't been built with it yet, don't have the gitignored properties I need to run the app. Anyway, I think it's good, if you're feeling lucky. :clap: 
